### PR TITLE
Create `twitter-rest-v2-tweet` 🎈 

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,3 @@
+source 'https://rubygems.org'
+
+gemspec

--- a/README.md
+++ b/README.md
@@ -2,3 +2,16 @@
 
 Just a patch [`twitter`](https://github.com/sferik/twitter) for only tweeting.<br/>
 (with Twitter V2 API)
+
+```rb
+require 'twitter/rest/v2/tweet'
+
+client = Twitter::REST::Client.new do |config|
+  config.consumer_key        = 'YOUR_CONSUMER_KEY'
+  config.consumer_secret     = 'YOUR_CONSUMER_SECRET'
+  config.access_token        = 'YOUR_ACCESS_TOKEN'
+  config.access_token_secret = 'YOUR_ACCESS_SECRET'
+end
+
+client.tweet_v2('Yeah!')
+```

--- a/lib/twitter-rest-v2-tweet.rb
+++ b/lib/twitter-rest-v2-tweet.rb
@@ -1,0 +1,1 @@
+require 'twitter/rest/v2/tweet'

--- a/lib/twitter/rest/v2/tweet.rb
+++ b/lib/twitter/rest/v2/tweet.rb
@@ -1,0 +1,16 @@
+require 'twitter'
+require 'twitter/rest/v2/tweet/tweet_v2'
+require 'twitter/rest/v2/tweet/version'
+
+module Twitter
+  module REST
+    module API
+      include Twitter::REST::V2::Tweet::TweetV2
+    end
+  end
+end
+
+# For `Twitter::Error::Unauthorized`.
+HTTP::MimeType.register_adapter(
+  'application/problem+json', HTTP::MimeType::JSON
+)

--- a/lib/twitter/rest/v2/tweet/tweet_v2.rb
+++ b/lib/twitter/rest/v2/tweet/tweet_v2.rb
@@ -1,0 +1,28 @@
+module Twitter
+  module REST
+    module V2
+      module Tweet
+        module TweetV2
+          include Twitter::REST::Utils
+          include Twitter::Utils
+
+          POST_TWEET_API_PATH = '/2/tweets'.freeze
+          private_constant :POST_TWEET_API_PATH
+
+          # @param text [String]
+          def tweet_v2(text)
+            perform_json_post(POST_TWEET_API_PATH, { text: text })
+          end
+
+          private
+
+          # @param path [String]
+          # @param options [Hash]
+          def perform_json_post(path, options)
+            perform_request(:json_post, path, options)
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/twitter/rest/v2/tweet/version.rb
+++ b/lib/twitter/rest/v2/tweet/version.rb
@@ -1,0 +1,9 @@
+module Twitter
+  module REST
+    module V2
+      module Tweet
+        VERSION = '1.0.0'.freeze
+      end
+    end
+  end
+end

--- a/twitter-rest-v2-tweet.gemspec
+++ b/twitter-rest-v2-tweet.gemspec
@@ -1,0 +1,22 @@
+lib = File.expand_path('../lib', __FILE__)
+$:.unshift(lib) unless $:.include?(lib)
+
+require 'twitter/rest/v2/tweet/version'
+
+Gem::Specification.new do |s|
+  s.name        = 'twitter-rest-v2-tweet'
+  s.version     = Twitter::REST::V2::Tweet::VERSION
+  s.platform    = Gem::Platform::RUBY
+  s.licenses    = 'MIT'
+  s.summary     = 'A Patch the `twitter` gem for tweeting'
+  s.email       = '-'
+  s.homepage    = 'https://github.com/SongCastle/twitter-rest-v2-tweet'
+  s.description = 'Patch `twitter` gem for tweeting by Twitter V2 API.'
+  s.author      = 'SongCastle'
+
+  s.files                 = Dir['lib/**/*', 'README.md']
+  s.require_paths         = ['lib']
+  s.required_ruby_version = Gem::Requirement.new('>= 3.0')
+
+  s.add_runtime_dependency('twitter', '>= 7.0.0')
+end


### PR DESCRIPTION
## Summary

Patch the [`twitter`](https://github.com/sferik/twitter) gem for tweeting (by Twitter V2 API).

```rb
require 'twitter/rest/v2/tweet'
client = Twitter::REST::Client.new do |config|
  config.consumer_key        = 'YOUR_CONSUMER_KEY'
  config.consumer_secret     = 'YOUR_CONSUMER_SECRET'
  config.access_token        = 'YOUR_ACCESS_TOKEN'
  config.access_token_secret = 'YOUR_ACCESS_SECRET'
end

client.tweet_v2('Yeah!')
```