### PR TITLE
Release 1.1.0 🎈 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+Gemfile.lock
+*.gem

--- a/.rspec
+++ b/.rspec
@@ -1,0 +1,1 @@
+--require spec_helper

--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,8 @@
 source 'https://rubygems.org'
 
 gemspec
+
+group :test do
+  gem 'rspec', '>= 3.12'
+  gem 'webmock'
+end

--- a/README.md
+++ b/README.md
@@ -6,12 +6,12 @@ Just a patch [`twitter`](https://github.com/sferik/twitter) for only tweet.<br/>
 ```rb
 require 'twitter/rest/v2/tweet'
 
-client = Twitter::REST::Client.new do |config|
-  config.consumer_key        = 'YOUR_CONSUMER_KEY'
-  config.consumer_secret     = 'YOUR_CONSUMER_SECRET'
-  config.access_token        = 'YOUR_ACCESS_TOKEN'
-  config.access_token_secret = 'YOUR_ACCESS_SECRET'
-end
+client = Twitter::REST::Client.new(
+  consumer_key: 'YOUR_CONSUMER_KEY',
+  consumer_secret: 'YOUR_CONSUMER_SECRET',
+  access_token: 'YOUR_ACCESS_TOKEN',
+  access_token_secret: 'YOUR_ACCESS_SECRET'
+)
 
 # Post a tweet.
 client.tweet_v2('Yeah!')

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # twitter-rest-v2-tweet
 
-Just a patch [`twitter`](https://github.com/sferik/twitter) for only tweeting.<br/>
+Just a patch [`twitter`](https://github.com/sferik/twitter) for only tweet.<br/>
 (with Twitter V2 API)
 
 ```rb
@@ -13,5 +13,9 @@ client = Twitter::REST::Client.new do |config|
   config.access_token_secret = 'YOUR_ACCESS_SECRET'
 end
 
+# Post a tweet.
 client.tweet_v2('Yeah!')
+
+# Delete a tweet by Tweet ID.
+client.untweet_v2('<YOUR_TWEET_ID>')
 ```

--- a/lib/twitter/rest/v2/tweet.rb
+++ b/lib/twitter/rest/v2/tweet.rb
@@ -13,6 +13,8 @@ module Twitter
 end
 
 # For `Twitter::Error::Unauthorized`.
-HTTP::MimeType.register_adapter(
-  'application/problem+json', HTTP::MimeType::JSON
-)
+if defined?(HTTP)
+  HTTP::MimeType.register_adapter(
+    'application/problem+json', HTTP::MimeType::JSON
+  )
+end

--- a/lib/twitter/rest/v2/tweet.rb
+++ b/lib/twitter/rest/v2/tweet.rb
@@ -1,11 +1,13 @@
 require 'twitter'
 require 'twitter/rest/v2/tweet/tweet_v2'
+require 'twitter/rest/v2/tweet/untweet_v2'
 require 'twitter/rest/v2/tweet/version'
 
 module Twitter
   module REST
     module API
       include Twitter::REST::V2::Tweet::TweetV2
+      include Twitter::REST::V2::Tweet::UntweetV2
     end
   end
 end

--- a/lib/twitter/rest/v2/tweet/untweet_v2.rb
+++ b/lib/twitter/rest/v2/tweet/untweet_v2.rb
@@ -1,0 +1,27 @@
+module Twitter
+  module REST
+    module V2
+      module Tweet
+        module UntweetV2
+          include Twitter::REST::Utils
+          include Twitter::Utils
+
+          DELETE_TWEET_API_PATH = '/2/tweets/%<id>s'.freeze
+          private_constant :DELETE_TWEET_API_PATH
+
+          # @param text [Integer|String]
+          def untweet_v2(id)
+            perform_delete(DELETE_TWEET_API_PATH % { id: id.to_s })
+          end
+
+          private
+
+          # @param path [String]
+          def perform_delete(path)
+            perform_request(:delete, path)
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/twitter/rest/v2/tweet/version.rb
+++ b/lib/twitter/rest/v2/tweet/version.rb
@@ -2,7 +2,7 @@ module Twitter
   module REST
     module V2
       module Tweet
-        VERSION = '1.0.0'.freeze
+        VERSION = '1.1.0'.freeze
       end
     end
   end

--- a/spec/helpers/request_helper.rb
+++ b/spec/helpers/request_helper.rb
@@ -1,0 +1,29 @@
+require 'webmock/rspec'
+
+module Twitter
+  module REST
+    module V2
+      module Tweet
+        module Spec
+          module RequestHelper
+            def a_post(path)
+              a_request(:post, Twitter::REST::Request::BASE_URL + path)
+            end
+
+            def a_delete(path)
+              a_request(:delete, Twitter::REST::Request::BASE_URL + path)
+            end
+
+            def stub_post(path)
+              stub_request(:post, Twitter::REST::Request::BASE_URL + path)
+            end
+
+            def stub_delete(path)
+              stub_request(:delete, Twitter::REST::Request::BASE_URL + path)
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,0 +1,12 @@
+$:.unshift(
+  File.expand_path(File.join(File.dirname(__FILE__), '..', 'lib')),
+  File.expand_path(File.join(File.dirname(__FILE__)))
+)
+
+require 'twitter/rest/v2/tweet'
+require 'rspec'
+require 'helpers/request_helper'
+
+RSpec.configure do |config|
+  config.include(Twitter::REST::V2::Tweet::Spec::RequestHelper)
+end

--- a/spec/twitter/rest/v2/tweet/tweet_v2_spec.rb
+++ b/spec/twitter/rest/v2/tweet/tweet_v2_spec.rb
@@ -1,0 +1,33 @@
+RSpec.describe Twitter::REST::V2::Tweet::TweetV2 do
+  describe '#tweet_v2' do
+    let(:client) do
+      Twitter::REST::Client.new(
+        consumer_key: '*****',
+        consumer_secret: '*****',
+        access_token: '*****',
+        access_token_secret: '*****'
+      )
+    end
+    let(:mock_body) do
+      {
+        data: {
+          edit_history_tweet_ids: ['0123456789'],
+          id: '0123456789',
+          text: 'Yeah!'
+        }
+      }
+    end
+
+    before do
+      stub_post('/2/tweets').to_return(
+        body: mock_body.to_json,
+        headers: { content_type: 'application/json; charset=UTF-8' }
+      )
+    end
+
+    it 'post a tweet by Twitter V2 API' do
+      expect(client.tweet_v2('Yeah!')).to eq(mock_body)
+      expect(a_post('/2/tweets').with(body: { text: 'Yeah!' })).to have_been_made.once
+    end
+  end
+end

--- a/spec/twitter/rest/v2/tweet/untweet_v2_spec.rb
+++ b/spec/twitter/rest/v2/tweet/untweet_v2_spec.rb
@@ -1,0 +1,31 @@
+RSpec.describe Twitter::REST::V2::Tweet::UntweetV2 do
+  describe '#untweet_v2' do
+    let(:client) do
+      Twitter::REST::Client.new(
+        consumer_key: '*****',
+        consumer_secret: '*****',
+        access_token: '*****',
+        access_token_secret: '*****'
+      )
+    end
+    let(:mock_body) do
+      {
+        data: {
+          deleted: true
+        }
+      }
+    end
+
+    before do
+      stub_delete('/2/tweets/0123456789').to_return(
+        body: mock_body.to_json,
+        headers: { content_type: 'application/json; charset=UTF-8' }
+      )
+    end
+
+    it 'delete a tweet by Twitter V2 API' do
+      expect(client.untweet_v2('0123456789')).to eq(mock_body)
+      expect(a_delete('/2/tweets/0123456789').with(body: {})).to have_been_made.once
+    end
+  end
+end

--- a/spec/twitter/rest/v2/tweet/version_spec.rb
+++ b/spec/twitter/rest/v2/tweet/version_spec.rb
@@ -1,0 +1,7 @@
+RSpec.describe Twitter::REST::V2::Tweet do
+  describe '::VERSION' do
+    it 'current version' do
+      expect(described_class::VERSION).to eq('1.0.0')
+    end
+  end
+end

--- a/spec/twitter/rest/v2/tweet/version_spec.rb
+++ b/spec/twitter/rest/v2/tweet/version_spec.rb
@@ -1,7 +1,7 @@
 RSpec.describe Twitter::REST::V2::Tweet do
   describe '::VERSION' do
     it 'current version' do
-      expect(described_class::VERSION).to eq('1.0.0')
+      expect(described_class::VERSION).to eq('1.1.0')
     end
   end
 end


### PR DESCRIPTION
# Summary

Add `#untweet_v2` (for deleting a tweet).

```rb
client = Twitter::REST::Client.new(
  consumer_key: 'YOUR_CONSUMER_KEY',
  consumer_secret: 'YOUR_CONSUMER_SECRET',
  access_token: 'YOUR_ACCESS_TOKEN',
  access_token_secret: 'YOUR_ACCESS_SECRET'
)

client.untweet_v2('<YOUR_TWEET_ID>')
```

### And ...

- Write unit tests.